### PR TITLE
Release for 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.2](https://github.com/handlename/obsidian-plugin-speed-cube/compare/0.0.1...0.0.2) - 2024-08-17
+- chore(deps-dev): bump @typescript-eslint/parser from 5.29.0 to 5.62.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/10
+- chore(deps-dev): bump ts-jest from 29.1.2 to 29.1.5 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/17
+- chore(deps-dev): bump @types/node from 20.12.8 to 20.14.9 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/16
+- braces v3.0.3 by @handlename in https://github.com/handlename/obsidian-plugin-speed-cube/pull/19
+- chore(deps-dev): bump builtin-modules from 3.3.0 to 4.0.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/2
+- chore(deps-dev): bump eslint from 8.57.0 to 9.9.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/18
+
 ## [0.0.1](https://github.com/handlename/obsidian-plugin-speed-cube/commits/0.0.1) - 2024-05-02
 - chore(deps-dev): bump tslib from 2.4.0 to 2.6.2 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/1
 - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.29.0 to 5.62.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/3

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-speedcube",
 	"name": "Speed Cube",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"minAppVersion": "0.15.0",
 	"description": "Demonstrates some of the capabilities of the Obsidian API.",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-speedcube",
 	"name": "Speed Cube",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"minAppVersion": "0.15.0",
 	"description": "Demonstrates some of the capabilities of the Obsidian API.",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-speedcube",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Plugin for Speed Cube",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This pull request is for the next release as 0.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps-dev): bump @typescript-eslint/parser from 5.29.0 to 5.62.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/10
* chore(deps-dev): bump ts-jest from 29.1.2 to 29.1.5 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/17
* chore(deps-dev): bump @types/node from 20.12.8 to 20.14.9 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/16
* braces v3.0.3 by @handlename in https://github.com/handlename/obsidian-plugin-speed-cube/pull/19
* chore(deps-dev): bump builtin-modules from 3.3.0 to 4.0.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/2
* chore(deps-dev): bump eslint from 8.57.0 to 9.9.0 by @dependabot in https://github.com/handlename/obsidian-plugin-speed-cube/pull/18


**Full Changelog**: https://github.com/handlename/obsidian-plugin-speed-cube/compare/0.0.1...0.0.2